### PR TITLE
Add File-Based Persistence for GPS Data

### DIFF
--- a/NF_GY-GPS6MV2/NF_GY-GPS6MV2.nfproj
+++ b/NF_GY-GPS6MV2/NF_GY-GPS6MV2.nfproj
@@ -57,6 +57,9 @@
     <Reference Include="System.Device.Wifi">
       <HintPath>..\packages\nanoFramework.System.Device.Wifi.1.5.133\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
+    <Reference Include="System.IO.FileSystem">
+      <HintPath>..\packages\nanoFramework.System.IO.FileSystem.1.1.87\lib\System.IO.FileSystem.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Ports">
       <HintPath>..\packages\nanoFramework.System.IO.Ports.1.1.132\lib\System.IO.Ports.dll</HintPath>
     </Reference>

--- a/NF_GY-GPS6MV2/packages.config
+++ b/NF_GY-GPS6MV2/packages.config
@@ -8,6 +8,7 @@
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.133" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.87" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Ports" version="1.1.132" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.43" targetFramework="netnano1.0" />


### PR DESCRIPTION
#### PR Classification
New feature to enhance GPS data handling by implementing file operations.

#### PR Summary
This pull request introduces functionality to save and load GPS data to and from a file, improving data persistence. Key changes include:
- `GpsService.cs`: Added methods `SaveLastGpsData()` and `LoadLastGpsData()` for handling GPS data serialization and deserialization.
- `GpsService.cs`: Introduced a constant `LAST_GPS_FILE` for the file path of the last GPS data.
- `GpsService.cs`: Modified the constructor to call `LoadLastGpsData()` during initialization.
- `NF_GY-GPS6MV2.nfproj`: Added a reference to the `System.IO.FileSystem` library for file operations.
- `packages.config`: Updated to include the `nanoFramework.System.IO.FileSystem` package.
